### PR TITLE
:hammer: Refactor: 중복된 router 등록 로직을 반복문으로 단순화

### DIFF
--- a/ai/app/server.py
+++ b/ai/app/server.py
@@ -14,10 +14,15 @@ logging.basicConfig(
 
 app = FastAPI()
 
-app.include_router(health_router, prefix="/api/ai")
-app.include_router(chatgpt_router, prefix="/api/ai")
-app.include_router(rag_router, prefix="/api/ai")
-app.include_router(embedding_router, prefix="/api/ai")
-app.include_router(build_router, prefix="/api/ai")
-app.include_router(reranker_router, prefix="/api/ai")
+routers = [
+    health_router,
+    chatgpt_router,
+    rag_router,
+    embedding_router,
+    build_router,
+    reranker_router
+]
 
+# 공통 prefix 적용
+for router in routers:
+    app.include_router(router, prefix="/api/ai")


### PR DESCRIPTION
- FastAPI app.include_router 호출 시 prefix가 모두 '/api/ai'로 동일하여 중복되는 코드를 반복문 기반으로 변경